### PR TITLE
fix/static_nameservers: Default value error

### DIFF
--- a/templates/resolv.conf
+++ b/templates/resolv.conf
@@ -1,7 +1,7 @@
 domain {{ bind__internal_domain }}
 search {{ bind__internal_domain }}{% if bind__additional_zones is defined %}{% for dom in bind__additional_zones.keys() %} {{ dom }}{% endfor %}{% endif %}
 
-{% if bind__static_nameservers|default({}) is iterable %}
+{% if bind__static_nameservers is defined and bind__static_nameservers is iterable %}
 {%   for ip in bind__static_nameservers %}
 nameserver {{ ip }}
 {%   endfor %}


### PR DESCRIPTION
On testing iterability on default value, we mask the lack of the variable, then it fails on for loop.