### PR TITLE
Fix log dir for apparmor compatibility

### DIFF
--- a/templates/named.conf.local
+++ b/templates/named.conf.local
@@ -69,14 +69,14 @@ zone "{{ bind__rpz_name }}" {
 {% if bind__logging %}
 logging {
         channel default_file {
-                file "/var/log/bind/named.log" versions 2 size 10m;
+                file "/var/log/named/named.log" versions 2 size 10m;
                 severity {{ bind__logging_named_severity }};
                 print-time yes;
                 print-severity yes;
                 print-category yes;
         };
         channel queries_file {
-                file "/var/log/bind/queries.log" versions 2 size 10m;
+                file "/var/log/named/queries.log" versions 2 size 10m;
                 severity {{ bind__logging_queries_severity }};
                 print-time yes;
                 print-severity yes;


### PR DESCRIPTION
b/c AppArmor use 'named' as log directory auth, the role must be adapted